### PR TITLE
Don't send flags that default to false.

### DIFF
--- a/droplet.go
+++ b/droplet.go
@@ -130,21 +130,15 @@ func (c *Client) CreateDroplet(opts *CreateDroplet) (string, error) {
 		params["ssh_keys[]"] = strings.Join(opts.SSHKeys, ",")
 	}
 
-	if opts.Backups == "" {
-		params["backups"] = "false"
-	} else {
+	if opts.Backups != "" && opts.Backups != "false" {
 		params["backups"] = opts.Backups
 	}
 
-	if opts.IPV6 == "" {
-		params["ipv6"] = "false"
-	} else {
+	if opts.IPV6 != "" && opts.IPV6 != "false" {
 		params["ipv6"] = opts.IPV6
 	}
 
-	if opts.PrivateNetworking == "" {
-		params["private_networking"] = "false"
-	} else {
+	if opts.PrivateNetworking != "" && opts.PrivateNetworking != "false" {
 		params["private_networking"] = opts.PrivateNetworking
 	}
 


### PR DESCRIPTION
When creating a droplet in a region that does not support private networking, sending `private_networking=false` causes an API error.

I suspect that this from a bug in [this](https://developers.digitalocean.com/changelog/api-v2/new-droplet-create-validations/) recent DO APIv2 update.

I found this when trying to use [terraform](https://github.com/hashicorp/terraform), which depends on this library.

