### PR TITLE
Use JSON API

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -60,25 +60,17 @@ func Test_NewClient_env(t *testing.T) {
 func TestClient_NewRequest(t *testing.T) {
 	c := makeClient(t)
 
-	params := map[string]string{
+	body := map[string]string{
 		"foo": "bar",
 		"baz": "bar",
 	}
-	req, err := c.NewRequest(params, "POST", "/bar")
+
+	req, err := c.NewRequest(body, "POST", "/bar")
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
 
-	encoded := req.URL.Query()
-	if encoded.Get("foo") != "bar" {
-		t.Fatalf("bad: %v", encoded)
-	}
-
-	if encoded.Get("baz") != "bar" {
-		t.Fatalf("bad: %v", encoded)
-	}
-
-	if req.URL.String() != "https://api.digitalocean.com/v2/bar?baz=bar&foo=bar" {
+	if req.URL.String() != "https://api.digitalocean.com/v2/bar" {
 		t.Fatalf("bad base url: %v", req.URL.String())
 	}
 

--- a/domain_test.go
+++ b/domain_test.go
@@ -19,9 +19,8 @@ func (s *S) Test_CreateDomain(c *C) {
 
 	id, err := s.client.CreateDomain(&opts)
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["name"], DeepEquals, []string{"example.com"})
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, "example.com")
 }

--- a/droplet.go
+++ b/droplet.go
@@ -99,15 +99,15 @@ func (d *Droplet) NetworkingType() string {
 // CreateDroplet contains the request parameters to create a new
 // droplet.
 type CreateDroplet struct {
-	Name              string   `json:"name"`               // Name of the droplet
-	Region            string   `json:"region"`             // Slug of the region to create the droplet in
-	Size              string   `json:"size"`               // Slug of the size to use for the droplet
-	Image             string   `json:"image"`              // Slug of the image, if using a public image
-	SSHKeys           []string `json:"ssh_keys"`           // Array of SSH Key IDs that should be added
-	Backups           string   `json:"backups"`            // 'true' or 'false' if backups are enabled
-	IPV6              string   `json:"ipv6"`               // 'true' or 'false' if IPV6 is enabled
-	PrivateNetworking string   `json:"private_networking"` // 'true' or 'false' if Private Networking is enabled
-	UserData          string   `json:"user_data"`          // metadata for the droplet
+	Name              string   `json:"name,omitempty"`               // Name of the droplet
+	Region            string   `json:"region,omitempty"`             // Slug of the region to create the droplet in
+	Size              string   `json:"size,omitempty"`               // Slug of the size to use for the droplet
+	Image             string   `json:"image,omitempty"`              // Slug of the image, if using a public image
+	SSHKeys           []string `json:"ssh_keys,omitempty"`           // Array of SSH Key IDs that should be added
+	Backups           string   `json:"backups,omitempty"`            // 'true' or 'false' if backups are enabled
+	IPV6              string   `json:"ipv6,omitempty"`               // 'true' or 'false' if IPV6 is enabled
+	PrivateNetworking string   `json:"private_networking,omitempty"` // 'true' or 'false' if Private Networking is enabled
+	UserData          string   `json:"user_data,omitempty"`          // metadata for the droplet
 }
 
 // CreateDroplet creates a droplet from the parameters specified and

--- a/droplet.go
+++ b/droplet.go
@@ -99,53 +99,23 @@ func (d *Droplet) NetworkingType() string {
 // CreateDroplet contains the request parameters to create a new
 // droplet.
 type CreateDroplet struct {
-	Name              string   // Name of the droplet
-	Region            string   // Slug of the region to create the droplet in
-	Size              string   // Slug of the size to use for the droplet
-	Image             string   // Slug of the image, if using a public image
-	SSHKeys           []string // Array of SSH Key IDs that should be added
-	Backups           string   // 'true' or 'false' if backups are enabled
-	IPV6              string   // 'true' or 'false' if IPV6 is enabled
-	PrivateNetworking string   // 'true' or 'false' if Private Networking is enabled
-	UserData          string   // metadata for the droplet
+	Name              string   `json:"name"`               // Name of the droplet
+	Region            string   `json:"region"`             // Slug of the region to create the droplet in
+	Size              string   `json:"size"`               // Slug of the size to use for the droplet
+	Image             string   `json:"image"`              // Slug of the image, if using a public image
+	SSHKeys           []string `json:"ssh_keys"`           // Array of SSH Key IDs that should be added
+	Backups           string   `json:"backups"`            // 'true' or 'false' if backups are enabled
+	IPV6              string   `json:"ipv6"`               // 'true' or 'false' if IPV6 is enabled
+	PrivateNetworking string   `json:"private_networking"` // 'true' or 'false' if Private Networking is enabled
+	UserData          string   `json:"user_data"`          // metadata for the droplet
 }
 
 // CreateDroplet creates a droplet from the parameters specified and
 // returns an error if it fails. If no error and an ID is returned,
 // the Droplet was succesfully created.
 func (c *Client) CreateDroplet(opts *CreateDroplet) (string, error) {
-	// Make the request parameters
-	params := make(map[string]string)
+	req, err := c.NewRequest(opts, "POST", "/droplets")
 
-	params["name"] = opts.Name
-	params["region"] = opts.Region
-	params["size"] = opts.Size
-
-	if opts.Image != "" {
-		params["image"] = opts.Image
-	}
-
-	for _, v := range opts.SSHKeys {
-		params["ssh_keys[]"] = v
-	}
-
-	if opts.Backups != "" && opts.Backups != "false" {
-		params["backups"] = opts.Backups
-	}
-
-	if opts.IPV6 != "" && opts.IPV6 != "false" {
-		params["ipv6"] = opts.IPV6
-	}
-
-	if opts.PrivateNetworking != "" && opts.PrivateNetworking != "false" {
-		params["private_networking"] = opts.PrivateNetworking
-	}
-
-	if opts.UserData != "" {
-		params["user_data"] = opts.UserData
-	}
-
-	req, err := c.NewRequest(params, "POST", "/droplets")
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +142,7 @@ func (c *Client) CreateDroplet(opts *CreateDroplet) (string, error) {
 // returns an error if it fails. If no error is returned,
 // the Droplet was succesfully destroyed.
 func (c *Client) DestroyDroplet(id string) error {
-	req, err := c.NewRequest(map[string]string{}, "DELETE", fmt.Sprintf("/droplets/%s", id))
+	req, err := c.NewRequest(nil, "DELETE", fmt.Sprintf("/droplets/%s", id))
 
 	if err != nil {
 		return err
@@ -192,7 +162,7 @@ func (c *Client) DestroyDroplet(id string) error {
 // returns a Droplet and an error. An error will be returned for failed
 // requests with a nil Droplet.
 func (c *Client) RetrieveDroplet(id string) (Droplet, error) {
-	req, err := c.NewRequest(map[string]string{}, "GET", fmt.Sprintf("/droplets/%s", id))
+	req, err := c.NewRequest(nil, "GET", fmt.Sprintf("/droplets/%s", id))
 
 	if err != nil {
 		return Droplet{}, err
@@ -217,7 +187,7 @@ func (c *Client) RetrieveDroplet(id string) (Droplet, error) {
 
 // Action sends the specified action to the droplet. An error
 // is retunred, and is nil if successful
-func (c *Client) Action(id string, action map[string]string) error {
+func (c *Client) Action(id string, action map[string]interface{}) error {
 	req, err := c.NewRequest(action, "POST", fmt.Sprintf("/droplets/%s/actions", id))
 
 	if err != nil {
@@ -235,7 +205,7 @@ func (c *Client) Action(id string, action map[string]string) error {
 
 // Resizes a droplet to the size slug specified
 func (c *Client) Resize(id string, size string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "resize",
 		"size": size,
 	})
@@ -243,7 +213,7 @@ func (c *Client) Resize(id string, size string) error {
 
 // Renames a droplet to the name specified
 func (c *Client) Rename(id string, name string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "rename",
 		"name": name,
 	})
@@ -251,28 +221,28 @@ func (c *Client) Rename(id string, name string) error {
 
 // Enables IPV6 on the droplet
 func (c *Client) EnableIPV6s(id string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "enable_ipv6",
 	})
 }
 
 // Enables private networking on the droplet
 func (c *Client) EnablePrivateNetworking(id string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "enable_private_networking",
 	})
 }
 
 // Resizes a droplet to the size slug specified
 func (c *Client) PowerOff(id string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "power_off",
 	})
 }
 
 // Resizes a droplet to the size slug specified
 func (c *Client) PowerOn(id string) error {
-	return c.Action(id, map[string]string{
+	return c.Action(id, map[string]interface{}{
 		"type": "power_on",
 	})
 }

--- a/droplet_test.go
+++ b/droplet_test.go
@@ -21,11 +21,8 @@ func (s *S) Test_CreateDroplet(c *C) {
 
 	id, err := s.client.CreateDroplet(&opts)
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["name"], DeepEquals, []string{"foobar"})
-	c.Assert(req.Form["user_data"], DeepEquals, []string{"baz"})
-	c.Assert(req.Form["ssh_keys[]"], DeepEquals, []string{"1"})
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, "25")
 }
@@ -84,11 +81,9 @@ func (s *S) Test_Resize(c *C) {
 
 	err := s.client.Resize("25", "1gb")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
-	c.Assert(req.Form["size"], DeepEquals, []string{"1gb"})
-	c.Assert(req.Form["type"], DeepEquals, []string{"resize"})
 }
 
 func (s *S) Test_Rename(c *C) {
@@ -96,11 +91,9 @@ func (s *S) Test_Rename(c *C) {
 
 	err := s.client.Rename("25", "foobar")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
-	c.Assert(req.Form["name"], DeepEquals, []string{"foobar"})
-	c.Assert(req.Form["type"], DeepEquals, []string{"rename"})
 }
 
 func (s *S) Test_EnableIPV6s(c *C) {
@@ -108,10 +101,9 @@ func (s *S) Test_EnableIPV6s(c *C) {
 
 	err := s.client.EnableIPV6s("25")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
-	c.Assert(req.Form["type"], DeepEquals, []string{"enable_ipv6"})
 }
 
 func (s *S) Test_EnablePrivateNetworking(c *C) {
@@ -119,10 +111,9 @@ func (s *S) Test_EnablePrivateNetworking(c *C) {
 
 	err := s.client.EnablePrivateNetworking("25")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
 	c.Assert(err, IsNil)
-	c.Assert(req.Form["type"], DeepEquals, []string{"enable_private_networking"})
 }
 
 func (s *S) Test_ActionError(c *C) {
@@ -130,9 +121,8 @@ func (s *S) Test_ActionError(c *C) {
 
 	err := s.client.EnablePrivateNetworking("25")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["type"], DeepEquals, []string{"enable_private_networking"})
 	c.Assert(err.Error(), Equals, "Error processing droplet action: API Error: unprocessable_entity: You specified an invalid size for Droplet creation.")
 }
 
@@ -141,9 +131,8 @@ func (s *S) Test_PowerOn(c *C) {
 
 	err := s.client.PowerOn("25")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["type"], DeepEquals, []string{"power_on"})
 	c.Assert(err, IsNil)
 }
 
@@ -152,9 +141,8 @@ func (s *S) Test_PowerOff(c *C) {
 
 	err := s.client.PowerOff("25")
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["type"], DeepEquals, []string{"power_off"})
 	c.Assert(err, IsNil)
 }
 

--- a/record_test.go
+++ b/record_test.go
@@ -21,11 +21,8 @@ func (s *S) Test_CreateRecord(c *C) {
 
 	id, err := s.client.CreateRecord("example.com", &opts)
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["type"], DeepEquals, []string{"A"})
-	c.Assert(req.Form["name"], DeepEquals, []string{"foobar"})
-	c.Assert(req.Form["data"], DeepEquals, []string{"10.0.0.1"})
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, "16")
 }
@@ -62,9 +59,8 @@ func (s *S) Test_UpdateRecord(c *C) {
 
 	err := s.client.UpdateRecord("example.com", "25", &opts)
 
-	req := testServer.WaitRequest()
+	_ = testServer.WaitRequest()
 
-	c.Assert(req.Form["name"], DeepEquals, []string{"foobaz"})
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
This converts this library to use the JSON API for creating and updating resources. Because of the param building, most functionality didn't need to be modified, including the API (function signatures).

Fixes #1022, #561